### PR TITLE
Fix modifier memoization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is a required setting.
 This gem comes with all the available modifiers that are supported natively by `image-resizer` but also allows you add your own modifier strings if you have built custom options into your own implementation.
 
     # config.add_modifier(key, alias='', values=[])
-    config.add_modifiers(:x, :xtra, ['one', 'two'])
+    config.add_modifier(:x, :xtra, ['one', 'two'])
 
 ### Sources
 As with modifiers you can add more external source options. Natively Facebook, Twitter, Youtube and Vimeo are supported but should you chose to add another to that list you can configure the gem with them

--- a/lib/ir_helper.rb
+++ b/lib/ir_helper.rb
@@ -29,11 +29,11 @@ module IrHelper
     end
 
     def add_modifier(key, img_tag = '', values = [])
-      @modifiers[key.to_sym] = { alias: img_tag, values: values }
+      modifiers[key.to_sym] = { alias: img_tag, values: values }
     end
 
     def add_source(name, option)
-      @modifiers[:e][:values][name.to_sym] = option.to_sym
+      modifiers[:e][:values][name.to_sym] = option.to_sym
     end
 
     def js_class


### PR DESCRIPTION
While messing around with adding modifiers I found that the memoization wasn't working. Unless `reset_config` was called first (like in the specs) `@modifiers` is `nil` because the `modifiers` method isn't called.

I also removed the 's' from `add_modifiers` in the README.
